### PR TITLE
Ensure .gitleaksignore can use relative paths when source parameter is set

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -176,6 +176,8 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 
 	// Setup common detector
 	detector := detect.NewDetector(cfg)
+
+	detector.SetBasePath(source)
 	// set color flag at first
 	if detector.NoColor, err = cmd.Flags().GetBool("no-color"); err != nil {
 		log.Fatal().Err(err).Msg("")

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -638,7 +638,7 @@ func TestFromFiles(t *testing.T) {
 	}
 }
 
-func TestRelativePathNoGit(t *testing.T) {
+func TestFromFilesRelativePath(t *testing.T) {
 	tests := []struct {
 		cfgName          string
 		source           string


### PR DESCRIPTION
### Description:
When the ```source``` parameter is set on ```nogit``` scans, the fingerprint generated contains the full path of the files with findings, meaning that ```.gitleaksignore``` will require full paths as well. This is not useful when gitleaks is run on build agents where the path can change between scans.

### Checklist:

* [X] Does your PR pass tests?
* [X] Have you written new tests for your changes?
* [X] Have you lint your code locally prior to submission?
